### PR TITLE
Prevent getItem from clearing $item->params

### DIFF
--- a/admin/compiler/joomla_3/JModelAdmin.php
+++ b/admin/compiler/joomla_3/JModelAdmin.php
@@ -82,7 +82,7 @@ class ###Component###Model###View### extends JModelAdmin
 	{###LICENSE_LOCKED_CHECK###
 		if ($item = parent::getItem($pk))
 		{
-			if (!empty($item->params))
+			if (!empty($item->params) && !is_array($item->params))
 			{
 				// Convert the params field to an array.
 				$registry = new Registry;


### PR DESCRIPTION
Additional check added to params test to ensure that if parent::getItem values are not removed if present.

Pull Request for Issue # .

### Summary of Changes

Added !is_array($item->params) test to getItem method.

### Testing Instructions

I'm bringing additional fields into my form via ajax and saving that data as param values.  Before the patch, param data is lost.  After the patch, param data remains.

### Expected result

param data remains

### Actual result

param data is lost

### Documentation Changes Required

This should be a transparent change for most users, as there isn't a facility in JCB to create param values in the forms.  It takes something weird like what I'm doing to notice it's an issue.