### PR TITLE
Implement onContentPrepare

### DIFF
--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -1654,12 +1654,6 @@ class Interpretation extends Fields
 	{
 		$fieldUikit = '';
 		$runplugins = false;
-		$context = array();
-		foreach(array('###component###','###view###') as $key) {
-			if(array_key_exists($key,$this->fileContentStatic)) {
-				$context[] = $this->fileContentStatic[$key];
-			}
-		}
 		foreach ($checker as $field => $array)
 		{
 			if (strpos($get['selection']['select'], $field) !== false)
@@ -1670,7 +1664,7 @@ class Interpretation extends Fields
 					$runplugins .= PHP_EOL."\t".$tab."\t".'$dispatcher = JEventDispatcher::getInstance();';
 				}
 				$fieldUikit .= PHP_EOL."\t".$tab."\t//".$this->setLine(__LINE__)." Make sure the content prepare plugins fire on ".$field;
-				$fieldUikit .= PHP_EOL."\t".$tab."\t".'$dispatcher->trigger("onContentPrepare",array("com_'.implode('.',$context).'",&'.$string.'->'.$field.',$item->params));';
+				$fieldUikit .= PHP_EOL."\t".$tab."\t".'$dispatcher->trigger("onContentPrepare",array($this->_context,&'.$string.'->'.$field.',$item->params));';
 				// only load for uikit version 2 (TODO) we may need to add another check here
 				if (2 == $this->uikit || 1 == $this->uikit)
 				{

--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -1660,7 +1660,7 @@ class Interpretation extends Fields
 			{
 				// build decoder string
 				if(!$runplugins) {
-					$runplugins  = PHP_EOL."\t".$tab."\tJPluginHelper::importPlugin('content');\n";
+					$runplugins  = PHP_EOL."\t".$tab."\tJPluginHelper::importPlugin('content');";
 					$runplugins .= PHP_EOL."\t".$tab."\t".'$dispatcher = JEventDispatcher::getInstance();';
 				}
 				$fieldUikit .= PHP_EOL."\t".$tab."\t//".$this->setLine(__LINE__)." Make sure the content prepare plugins fire on ".$field;

--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -1658,8 +1658,12 @@ class Interpretation extends Fields
 			if (strpos($get['selection']['select'], $field) !== false)
 			{
 				// build decoder string
-				$fieldUikit .= PHP_EOL."\t".$tab."\t//".$this->setLine(__LINE__)." Make sure the content prepare plugins fire on ".$field." (TODO)";
-				$fieldUikit .= PHP_EOL."\t".$tab."\t".$string."->".$field." = JHtml::_('content.prepare',".$string."->".$field.");";
+				if(!$runplugins) {
+					$runplugins  = PHP_EOL."\t".$tab."\tJPluginHelper::importPlugin('content');\n";
+					$runplugins .= PHP_EOL."\t".$tab."\t".'$dispatcher = JEventDispatcher::getInstance();';
+				}
+				$fieldUikit .= PHP_EOL."\t".$tab."\t//".$this->setLine(__LINE__)." Make sure the content prepare plugins fire on ".$field;
+				$fieldUikit .= PHP_EOL."\t".$tab."\t".'$dispatcher->trigger("onContentPrepare",array("com_'.$this->fileContentStatic['###component###'].'.'.$this->fileContentStatic['###view###'].'",&'.$string.'->'.$field.',$item->params));';
 				// only load for uikit version 2 (TODO) we may need to add another check here
 				if (2 == $this->uikit || 1 == $this->uikit)
 				{
@@ -1668,7 +1672,7 @@ class Interpretation extends Fields
 				}
 			}
 		}
-		return $fieldUikit;
+		return ($runplugins?:'').$fieldUikit;
 	}
 
 	public function setCustomViewCustomJoin(&$gets,$string,$code,&$asBucket,$tab = '')

--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -1653,6 +1653,13 @@ class Interpretation extends Fields
 	public function setCustomViewFieldUikitChecker(&$get, $checker, $string, $code, $tab = '')
 	{
 		$fieldUikit = '';
+		$runplugins = false;
+		$context = array();
+		foreach(array('###component###','###view###') as $key) {
+			if(array_key_exists($key,$this->fileContentStatic)) {
+				$context[] = $this->fileContentStatic[$key];
+			}
+		}
 		foreach ($checker as $field => $array)
 		{
 			if (strpos($get['selection']['select'], $field) !== false)
@@ -1663,7 +1670,7 @@ class Interpretation extends Fields
 					$runplugins .= PHP_EOL."\t".$tab."\t".'$dispatcher = JEventDispatcher::getInstance();';
 				}
 				$fieldUikit .= PHP_EOL."\t".$tab."\t//".$this->setLine(__LINE__)." Make sure the content prepare plugins fire on ".$field;
-				$fieldUikit .= PHP_EOL."\t".$tab."\t".'$dispatcher->trigger("onContentPrepare",array("com_'.$this->fileContentStatic['###component###'].'.'.$this->fileContentStatic['###view###'].'",&'.$string.'->'.$field.',$item->params));';
+				$fieldUikit .= PHP_EOL."\t".$tab."\t".'$dispatcher->trigger("onContentPrepare",array("com_'.implode('.',$context).'",&'.$string.'->'.$field.',$item->params));';
 				// only load for uikit version 2 (TODO) we may need to add another check here
 				if (2 == $this->uikit || 1 == $this->uikit)
 				{


### PR DESCRIPTION
Pull Request for Issue #111  .

### Summary of Changes

Implement onContentPrepare

### Testing Instructions

The easiest test is to create an editor field and within it type an email address.  If the Email Cloaking plugin is enabled, the output should have a cloaked email address.  

### Expected result

it works

### Actual result

it works

### Documentation Changes Required

tell people it works?