### PR TITLE
Improment to language constant replacment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Contributing to the Joomla Component Builder (JCB)
 ===============
 You are welcome to submit a contribution for review and possible inclusion in the Joomla Component Builder but, before it will be accepted, we ask that you follow these simple steps:
 
-1) Please watch [these tutorials](https://www.youtube.com/watch?v=4pNBMOYoJpI&list=PLQRGFI8XZ_wsfz3NdKawCiYsALuZ-GhwJ)
+1) Please watch [these tutorials](https://www.youtube.com/watch?v=lLOfx9YA7VQ&list=PLQRGFI8XZ_wsfz3NdKawCiYsALuZ-GhwJ)
 
 2) Open an issue on GitHub. If you can, please provide a fix and create a pull request (PR) instead; this will automatically create an issue for you so you do not have to create an issue if you are creating a pull request.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,15 @@
-Pull Request for Issue # .
+Pull Request for Issue gh- .
 
 ### Summary of Changes
-
 
 
 ### Testing Instructions
 
 
-
 ### Expected result
 
 
-
 ### Actual result
-
 
 
 ### Documentation Changes Required

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Component Builder is mapped as a component in itself on my local development env
 + *Author*: [Llewellyn van der Merwe](mailto:joomla@vdm.io)
 + *Name*: [Component Builder](http://vdm.bz/component-builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 12th December, 2017
++ *Last Build*: 14th December, 2017
 + *Version*: 2.6.6
 + *Copyright*: Copyright (C) 2015. All Rights Reserved
 + *License*: GNU/GPL Version 2 or later - http://www.gnu.org/licenses/gpl-2.0.html
-+ *Line count*: **177938**
++ *Line count*: **177939**
 + *File count*: **1142**
 + *Folder count*: **184**
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Component Builder is mapped as a component in itself on my local development env
 + *Version*: 2.6.6
 + *Copyright*: Copyright (C) 2015. All Rights Reserved
 + *License*: GNU/GPL Version 2 or later - http://www.gnu.org/licenses/gpl-2.0.html
-+ *Line count*: **177939**
++ *Line count*: **177938**
 + *File count*: **1142**
 + *Folder count*: **184**
 

--- a/admin/README.txt
+++ b/admin/README.txt
@@ -111,11 +111,11 @@ Component Builder is mapped as a component in itself on my local development env
 + *Author*: [Llewellyn van der Merwe](mailto:joomla@vdm.io)
 + *Name*: [Component Builder](http://vdm.bz/component-builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 12th December, 2017
++ *Last Build*: 14th December, 2017
 + *Version*: 2.6.6
 + *Copyright*: Copyright (C) 2015. All Rights Reserved
 + *License*: GNU/GPL Version 2 or later - http://www.gnu.org/licenses/gpl-2.0.html
-+ *Line count*: **177938**
++ *Line count*: **177939**
 + *File count*: **1142**
 + *Folder count*: **184**
 

--- a/admin/README.txt
+++ b/admin/README.txt
@@ -115,7 +115,7 @@ Component Builder is mapped as a component in itself on my local development env
 + *Version*: 2.6.6
 + *Copyright*: Copyright (C) 2015. All Rights Reserved
 + *License*: GNU/GPL Version 2 or later - http://www.gnu.org/licenses/gpl-2.0.html
-+ *Line count*: **177939**
++ *Line count*: **177938**
 + *File count*: **1142**
 + *Folder count*: **184**
 

--- a/admin/controllers/compiler.php
+++ b/admin/controllers/compiler.php
@@ -105,6 +105,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 				$message .= '<ul>';
 				$message .= '<li>Total folders created: <b>'.$model->compiler->folderCount.'</b></li>';
 				$message .= '<li>Total files created: <b>'.$model->compiler->fileCount.'</b></li>';
+				$message .= '<li>Total fields created: <b>'.$model->compiler->fieldCount.'</b></li>';
 				$message .= '<li>Total lines written: <b>'.$model->compiler->lineCount.'</b></li>';
 				$message .= '<li>A4 Book of: <b>'.$model->compiler->pageCount.' pages</b></li>';
 				$message .= '</ul>';

--- a/admin/controllers/snippets.php
+++ b/admin/controllers/snippets.php
@@ -150,12 +150,12 @@ class ComponentbuilderControllerSnippets extends JControllerAdmin
 				if (count($pks) > 1)
 				{
 					$message = '<h1>' . JText::_('COM_COMPONENTBUILDER_THE_SNIPPETS_WERE_SUCCESSFULLY_EXPORTED') . '</h1>';
-					$message .= '<p>' . JText::sprintf('To share these snippets with the rest of the JCB community,');
+					$message .= '<p>' . JText::sprintf('COM_COMPONENTBUILDER_TO_SHARE_THESE_SNIPPETS_WITH_THE_REST_OF_THE_JCB_COMMUNITY');
 				}
 				else
 				{
 					$message = '<h1>' . JText::_('COM_COMPONENTBUILDER_THE_SNIPPET_WAS_SUCCESSFULLY_EXPORTED') . '</h1>';
-					$message .= '<p>' . JText::sprintf('To share this snippet with the rest of the JCB community,');
+					$message .= '<p>' . JText::sprintf('COM_COMPONENTBUILDER_TO_SHARE_THIS_SNIPPET_WITH_THE_REST_OF_THE_JCB_COMMUNITY');
 				}
 				$message .= JText::sprintf('COM_COMPONENTBUILDER_YOU_WILL_NEED_TO_KNOW_HOW_S_WORKS_BASIC_YOU_WILL_ALSO_NEED_A_S_ACCOUNT_AND_KNOW_HOW_TO_MAKE_A_PULL_REQUEST_ON_GITHUB', 
 					'<a href="https://try.github.io" target="_blank">git</a>',

--- a/admin/helpers/compiler.php
+++ b/admin/helpers/compiler.php
@@ -146,6 +146,38 @@ class Compiler extends Infusion
 				// done with error
 				return false;
 			}
+			// do lang mismatch check
+			if (ComponentbuilderHelper::checkArray($this->langMismatch))
+			{
+				if (ComponentbuilderHelper::checkArray($this->langMatch))
+				{
+					$mismatch = array_diff(array_unique($this->langMismatch), array_unique($this->langMatch));
+				}
+				else
+				{
+					$mismatch = array_unique($this->langMismatch);
+				}
+				// set a notice if we have a mismatch
+				if (ComponentbuilderHelper::checkArray($mismatch))
+				{
+					if (count($mismatch) > 1)
+					{
+						$this->app->enqueueMessage(JText::_('<h3>Please check the following mismatching Joomla.JText language constants.</h3>'), 'Warning');
+					}
+					else
+					{
+						$this->app->enqueueMessage(JText::_('<h3>Please check the following mismatch Joomla.JText language constant.</h3>'), 'Warning');
+					}
+					// add the mismatching issues
+					foreach ($mismatch as $string)
+					{
+						$constant = $this->langPrefix.'_'.ComponentbuilderHelper::safeString($string,'U');
+						$this->app->enqueueMessage(JText::sprintf('The <b>Joomla.JText._(\'%s\')</b> language constant for (%s) does not have a corresponding JText::Script() decalaration.', 
+									$constant, $string), 'Warning');
+					}
+					$this->app->enqueueMessage('<hr />', 'Warning');
+				}
+			}
 			// end the timer here
 			$this->time_end = microtime(true);
 			$this->secondsCompiled = $this->time_end - $this->time_start;
@@ -396,6 +428,7 @@ class Compiler extends Infusion
 	{
 		// set some defaults
 		$this->fileContentStatic['###LINE_COUNT###']		= $this->lineCount;
+		$this->fileContentStatic['###FIELD_COUNT###']		= $this->fieldCount;
 		$this->fileContentStatic['###FILE_COUNT###']		= $this->fileCount;
 		$this->fileContentStatic['###FOLDER_COUNT###']		= $this->folderCount;
 		$this->fileContentStatic['###PAGE_COUNT###']		= $this->pageCount;

--- a/admin/helpers/compiler/b_Structure.php
+++ b/admin/helpers/compiler/b_Structure.php
@@ -60,6 +60,13 @@ class Structure extends Get
 	public $lineCount = 0;
 	
 	/**
+	 * The field counter
+	 * 
+	 * @var     int
+	 */
+	public $fieldCount = 0;
+	
+	/**
 	 * The seconds counter
 	 * 
 	 * @var     int

--- a/admin/helpers/compiler/c_Fields.php
+++ b/admin/helpers/compiler/c_Fields.php
@@ -497,6 +497,8 @@ class Fields extends Structure
 				);
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if created is not set
 			if (!isset($this->fieldsNames[$viewName]['created']))
@@ -514,6 +516,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Date Created Field. Type: Calendar (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if created_by is not set
 			if (!isset($this->fieldsNames[$viewName]['created_by']))
@@ -528,6 +532,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " User Created Field. Type: User (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if published is not set
 			if (!isset($this->fieldsNames[$viewName]['published']))
@@ -541,6 +547,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Published Field. Type: List (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 				foreach (array('JPUBLISHED' => 1, 'JUNPUBLISHED' => 0, 'JARCHIVED' => 2, 'JTRASHED' => -2) as $text => $value)
 				{
 					$optionXML = $fieldXML->addChild('option');
@@ -565,6 +573,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Date Modified Field. Type: Calendar (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if modified_by is not set
 			if (!isset($this->fieldsNames[$viewName]['modified_by']))
@@ -581,6 +591,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " User Modified Field. Type: User (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// check if view has access
 			if (isset($this->accessBuilder[$viewName]) && ComponentbuilderHelper::checkString($this->accessBuilder[$viewName]) && !isset($this->fieldsNames[$viewName]['access']))
@@ -597,6 +609,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Access Field. Type: Accesslevel (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if ordering is not set
 			if (!isset($this->fieldsNames[$viewName]['ordering']))
@@ -615,6 +629,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Ordering Field. Type: Numbers (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// if version is not set
 			if (!isset($this->fieldsNames[$viewName]['version']))
@@ -632,6 +648,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Version Field. Type: Text (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// check if metadata is added to this view
 			if (isset($this->metadataBuilder[$viewName]) && ComponentbuilderHelper::checkString($this->metadataBuilder[$viewName]))
@@ -648,6 +666,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Metakey Field. Type: Textarea (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 				// metadesc
 				$attributes['name'] = 'metadesc';
 				$attributes['label'] = 'JFIELD_META_DESCRIPTION_LABEL';
@@ -655,6 +675,8 @@ class Fields extends Structure
 				$this->xmlComment($fieldSetXML, $this->setLine(__LINE__) . " Metadesc Field. Type: Textarea (joomla)");
 				$fieldXML = $fieldSetXML->addChild('field');
 				$this->xmlAddAttributes($fieldXML, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// load the dynamic fields now
 			if (count($dynamicFieldsXML))
@@ -685,6 +707,8 @@ class Fields extends Structure
 				    'description' => 'JFIELD_METADATA_ROBOTS_DESC'
 				);
 				$this->xmlAddAttributes($robots, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 				$options = array(
 				    'JGLOBAL_USE_GLOBAL' => '',
 				    'JGLOBAL_INDEX_FOLLOW' => 'index, follow',
@@ -709,6 +733,8 @@ class Fields extends Structure
 				    'size' => 20
 				);
 				$this->xmlAddAttributes($author, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 				// rights
 				$this->xmlComment($fieldsFieldSetXML, $this->setLine(__LINE__) . " Rights Field. Type: Textarea (joomla)");
 				$rights = $fieldsFieldSetXML->addChild('field');
@@ -723,6 +749,8 @@ class Fields extends Structure
 				    'rows' => 2
 				);
 				$this->xmlAddAttributes($rights, $attributes);
+				// count the static field created
+				$this->fieldCount++;
 			}
 			// just to be safe, lets clear the view placeholders
 			$this->clearFromPlaceHolders('view');
@@ -2342,7 +2370,8 @@ class Fields extends Structure
 	public function xmlAppend(&$xml, $node)
 	{
 		if (!$node)
-		{ // element was not returned
+		{
+			// element was not returned
 			return;
 		}
 		switch (get_class($node))
@@ -2364,6 +2393,8 @@ class Fields extends Structure
 				$xml = simplexml_import_dom($domXML);
 				break;
 		}
+		// count the dynamic fields created
+		$this->fieldCount++;
 	}
 
 	/**

--- a/admin/views/get_snippets/view.html.php
+++ b/admin/views/get_snippets/view.html.php
@@ -189,38 +189,38 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 		// set an error message if needed
 		$this->document->addScriptDeclaration("var returnError = '<div class=\"uk-alert uk-alert-warning\"><h1>".JText::_('COM_COMPONENTBUILDER_AN_ERROR_HAS_OCCURRED')."!</h1><p>".JText::_('COM_COMPONENTBUILDER_PLEASE_TRY_AGAIN_LATER').".</p></div>';");
 		// need to add some language strings
-		$this->document->addScriptDeclaration("var lang_Community_Snippets = '".JText::_('COM_COMPONENTBUILDER_JCB_COMMUNITY_SNIPPETS')."';");
-		$this->document->addScriptDeclaration("var lang_Snippets = '".JText::_('COM_COMPONENTBUILDER_SNIPPETS')."';");
-		$this->document->addScriptDeclaration("var lang_Snippet = '".JText::_('COM_COMPONENTBUILDER_SNIPPET')."';");
-		$this->document->addScriptDeclaration("var lang_Snippet_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_SNIPPET_OF_COMMUNITY_VERSION')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippet = '".JText::_('COM_COMPONENTBUILDER_GET_SNIPPET')."';");
-		$this->document->addScriptDeclaration("var lang_Dont_Get_Snippet = '".JText::_('COM_COMPONENTBUILDER_LOCAL_SNIPPET')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippet_Tooltip = '".JText::_('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_UPDATE_THE_LOCAL_VERSION')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippet_New_Tooltip = '".JText::_('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_INSTALL_IT_LOCALLY')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippet_Dont_Tooltip = '".JText::_('COM_COMPONENTBUILDER_NO_NEED_TO_GET_IT_SINCE_IT_IS_ALREADY_IN_SYNC_WITH_YOUR_LOCAL_VERSION')."';");
-		$this->document->addScriptDeclaration("var lang_Usage = '".JText::_('COM_COMPONENTBUILDER_USAGE')."';");
-		$this->document->addScriptDeclaration("var lang_Usage_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_USAGE_OF_COMMUNITY_VERSION')."';");
-		$this->document->addScriptDeclaration("var lang_Description = '".JText::_('COM_COMPONENTBUILDER_DESCRIPTION')."';");
-		$this->document->addScriptDeclaration("var lang_Description_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_DESCRIPTION_OF_COMMUNITY_VERSION')."';");
-		$this->document->addScriptDeclaration("var lang_View_Blame = '".JText::_('COM_COMPONENTBUILDER_VIEW_BLAME')."';");
-		$this->document->addScriptDeclaration("var lang_View_Blame_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_WHO_CONTRIBUTED_TO_THIS_SNIPPET')."';");
-		$this->document->addScriptDeclaration("var lang_URL_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_SNIPPET_REFERENCE_URL')."';");
-		$this->document->addScriptDeclaration("var lang_Update_Error_Tooltip = '".JText::_('COM_COMPONENTBUILDER_SNIPPET_COULD_NOT_BE_UPDATEDSAVED')."';");
-		$this->document->addScriptDeclaration("var lang_Updates_Error_Tooltip = '".JText::_('COM_COMPONENTBUILDER_SNIPPETS_COULD_NOT_BE_UPDATEDSAVED')."';");
-		$this->document->addScriptDeclaration("var lang_Contributor_URL_Tooltip = '".JText::_('COM_COMPONENTBUILDER_LINK_TO_THE_CONTRIBUTOR')."';");
-		$this->document->addScriptDeclaration("var lang_Contributor_Modal_Tooltip = '".JText::_('COM_COMPONENTBUILDER_VIEW_THE_CONTRIBUTOR_DETAILS')."';");
-		$this->document->addScriptDeclaration("var lang_JCB_Community = '".JText::_('COM_COMPONENTBUILDER_JCB_COMMUNITY')."';");
-		$this->document->addScriptDeclaration("var lang_Company_Name = '".JText::_('COM_COMPONENTBUILDER_COMPANY_NAME')."';");
-		$this->document->addScriptDeclaration("var lang_Author_Name = '".JText::_('COM_COMPONENTBUILDER_AUTHOR_NAME')."';");
-		$this->document->addScriptDeclaration("var lang_Author_Email = '".JText::_('COM_COMPONENTBUILDER_AUTHOR_EMAIL')."';");
-		$this->document->addScriptDeclaration("var lang_Author_Website = '".JText::_('COM_COMPONENTBUILDER_AUTHOR_WEBSITE')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippets_New_Tooltip = '".JText::_('COM_COMPONENTBUILDER_THERE_ARE_NO_NEW_SNIPPETS_AT_THIS_TIME')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippets_Diverged_Tooltip = '".JText::_('COM_COMPONENTBUILDER_THERE_ARE_NO_DIVERGED_SNIPPETS_AT_THIS_TIME')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippets_Ahead_Tooltip = '".JText::_('COM_COMPONENTBUILDER_THERE_ARE_NO_AHEAD_SNIPPETS_AT_THIS_TIME')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippets_Behind_Tooltip = '".JText::_('COM_COMPONENTBUILDER_THERE_ARE_NO_OUT_OF_DATE_SNIPPETS_AT_THIS_TIME')."';");
-		$this->document->addScriptDeclaration("var lang_Get_Snippets_All_Tooltip = '".JText::_('COM_COMPONENTBUILDER_THERE_ARE_NO_SNIPPETS_TO_UPDATE_AT_THIS_TIME')."';");
-		$this->document->addScriptDeclaration("var lang_Available_Libraries = '".JText::_('COM_COMPONENTBUILDER_AVAILABLE_LIBRARIES')."';");
-		$this->document->addScriptDeclaration("var lang_Open_Lib_Snippets = '".JText::_('COM_COMPONENTBUILDER_OPEN_LIBRARY_SNIPPETS')."';");
+		JText::script('COM_COMPONENTBUILDER_JCB_COMMUNITY_SNIPPETS');
+		JText::script('COM_COMPONENTBUILDER_SNIPPETS');
+		JText::script('COM_COMPONENTBUILDER_SNIPPET');
+		JText::script('COM_COMPONENTBUILDER_VIEW_SNIPPET_OF_COMMUNITY_VERSION');
+		JText::script('COM_COMPONENTBUILDER_GET_SNIPPET');
+		JText::script('COM_COMPONENTBUILDER_LOCAL_SNIPPET');
+		JText::script('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_UPDATE_THE_LOCAL_VERSION');
+		JText::script('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_INSTALL_IT_LOCALLY');
+		JText::script('COM_COMPONENTBUILDER_NO_NEED_TO_GET_IT_SINCE_IT_IS_ALREADY_IN_SYNC_WITH_YOUR_LOCAL_VERSION');
+		JText::script('COM_COMPONENTBUILDER_USAGE');
+		JText::script('COM_COMPONENTBUILDER_VIEW_USAGE_OF_COMMUNITY_VERSION');
+		JText::script('COM_COMPONENTBUILDER_DESCRIPTION');
+		JText::script('COM_COMPONENTBUILDER_VIEW_DESCRIPTION_OF_COMMUNITY_VERSION');
+		JText::script('COM_COMPONENTBUILDER_VIEW_BLAME');
+		JText::script('COM_COMPONENTBUILDER_VIEW_WHO_CONTRIBUTED_TO_THIS_SNIPPET');
+		JText::script('COM_COMPONENTBUILDER_VIEW_SNIPPET_REFERENCE_URL');
+		JText::script('COM_COMPONENTBUILDER_SNIPPET_COULD_NOT_BE_UPDATEDSAVED');
+		JText::script('COM_COMPONENTBUILDER_SNIPPETS_COULD_NOT_BE_UPDATEDSAVED');
+		JText::script('COM_COMPONENTBUILDER_LINK_TO_THE_CONTRIBUTOR');
+		JText::script('COM_COMPONENTBUILDER_VIEW_THE_CONTRIBUTOR_DETAILS');
+		JText::script('COM_COMPONENTBUILDER_JCB_COMMUNITY');
+		JText::script('COM_COMPONENTBUILDER_COMPANY_NAME');
+		JText::script('COM_COMPONENTBUILDER_AUTHOR_NAME');
+		JText::script('COM_COMPONENTBUILDER_AUTHOR_EMAIL');
+		JText::script('COM_COMPONENTBUILDER_AUTHOR_WEBSITE');
+		JText::script('COM_COMPONENTBUILDER_THERE_ARE_NO_NEW_SNIPPETS_AT_THIS_TIME');
+		JText::script('COM_COMPONENTBUILDER_THERE_ARE_NO_DIVERGED_SNIPPETS_AT_THIS_TIME');
+		JText::script('COM_COMPONENTBUILDER_THERE_ARE_NO_AHEAD_SNIPPETS_AT_THIS_TIME');
+		JText::script('COM_COMPONENTBUILDER_THERE_ARE_NO_OUT_OF_DATE_SNIPPETS_AT_THIS_TIME');
+		JText::script('COM_COMPONENTBUILDER_THERE_ARE_NO_SNIPPETS_TO_UPDATE_AT_THIS_TIME');
+		JText::script('COM_COMPONENTBUILDER_AVAILABLE_LIBRARIES');
+		JText::script('COM_COMPONENTBUILDER_OPEN_LIBRARY_SNIPPETS');
 		// add some lang verfy messages
 		$this->document->addScriptDeclaration("
 			// set the snippet from gitHub
@@ -302,7 +302,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 					//do something special
 					if ('snippets' === ajaxcall) {
 						setTimeout( function() {
-							jQuery('#snippets-github').html('<h1>'+lang_Community_Snippets+'</h1>');
+							jQuery('#snippets-github').html('<h1>'+Joomla.JText._('COM_COMPONENTBUILDER_JCB_COMMUNITY_SNIPPETS')+'</h1>');
 							jQuery('#snippets-display').show();
 							jQuery('#snippets-grid').trigger('display.uk.check');
 							jQuery('#loading').hide();
@@ -362,7 +362,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 					setLibrary(value);
 				});
 				setTimeout( function() {
-					jQuery('#snippets-github').html('<h1>'+lang_Available_Libraries+'</h1>');
+					jQuery('#snippets-github').html('<h1>'+Joomla.JText._('COM_COMPONENTBUILDER_AVAILABLE_LIBRARIES')+'</h1>');
 					jQuery('#libraries-display').show();
 					jQuery('#libraries-grid').trigger('display.uk.check');
 				}, 1000);
@@ -387,7 +387,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 			}
 			
 			function setLibButtons(name) {
-				return  '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-1 getreaction\" data-name=\"'+name+'\" data-type=\"getSnippets\" title=\"'+lang_Description_Tooltip+'\"><i class=\"uk-icon-thumb-tack\"></i><span class=\"uk-hidden-small\"> '+lang_Open_Lib_Snippets+'</span></button>';
+				return  '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-1 getreaction\" data-name=\"'+name+'\" data-type=\"getSnippets\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_DESCRIPTION_OF_COMMUNITY_VERSION')+'\"><i class=\"uk-icon-thumb-tack\"></i><span class=\"uk-hidden-small\"> '+Joomla.JText._('COM_COMPONENTBUILDER_OPEN_LIBRARY_SNIPPETS')+'</span></button>';
 			}
 			
 			// get the snippets
@@ -404,7 +404,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 				fromLocal = false;
 				if (_paths) {
 					setSnippets(_paths, libraryName);
-					jQuery('#snippets-github').html('<h1>'+lang_Community_Snippets+'</h1>');
+					jQuery('#snippets-github').html('<h1>'+Joomla.JText._('COM_COMPONENTBUILDER_JCB_COMMUNITY_SNIPPETS')+'</h1>');
 				} else {
 					jQuery.get(path)
 					.success(function(paths) {
@@ -506,27 +506,27 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 			
 			function setDataButtons(snippet, key, status) {
 				var html = '<div class=\"uk-button-group uk-width-1-1 uk-margin-small-bottom\">';
-				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"usage\" title=\"'+lang_Usage_Tooltip+'\"><i class=\"uk-icon-info\"></i><span class=\"uk-hidden-small\"> '+lang_Usage+'</span></button>';
-				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"description\" title=\"'+lang_Description_Tooltip+'\"><i class=\"uk-icon-sticky-note-o\"></i><span class=\"uk-hidden-small\"> '+lang_Description+'</span></button>';
-				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"snippet\" title=\"'+lang_Snippet_Tooltip+'\"><i class=\"uk-icon-code\"></i><span class=\"uk-hidden-small\"> '+lang_Snippet+'</span></button>';
+				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"usage\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_USAGE_OF_COMMUNITY_VERSION')+'\"><i class=\"uk-icon-info\"></i><span class=\"uk-hidden-small\"> '+Joomla.JText._('COM_COMPONENTBUILDER_USAGE')+'</span></button>';
+				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"description\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_DESCRIPTION_OF_COMMUNITY_VERSION')+'\"><i class=\"uk-icon-sticky-note-o\"></i><span class=\"uk-hidden-small\"> '+Joomla.JText._('COM_COMPONENTBUILDER_DESCRIPTION')+'</span></button>';
+				html += '<button class=\"uk-button uk-button-small uk-button-success uk-width-1-3 getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"snippet\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_SNIPPET_OF_COMMUNITY_VERSION')+'\"><i class=\"uk-icon-code\"></i><span class=\"uk-hidden-small\"> '+Joomla.JText._('COM_COMPONENTBUILDER_SNIPPET')+'</span></button>';
 				html += '</div>';
 				// return data buttons
 				return html;
 			}
 			
 			function setRefButtons(snippet, key, status, keyID) {
-				var html = '<div><a class=\"uk-button uk-button-mini uk-button-success uk-margin-small-bottom uk-width-1-1\" href=\"'+snippet.url+'\" target=\"_blank\" title=\"'+lang_URL_Tooltip+'\"><i class=\"uk-icon-external-link\"></i> ' + snippet.name + '</a></div>';
+				var html = '<div><a class=\"uk-button uk-button-mini uk-button-success uk-margin-small-bottom uk-width-1-1\" href=\"'+snippet.url+'\" target=\"_blank\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_SNIPPET_REFERENCE_URL')+'\"><i class=\"uk-icon-external-link\"></i> ' + snippet.name + '</a></div>';
 				// set the update button	
 				html += '<div>';
 				if ('equal' !== status) {
 					if ('new' === status) {
-						var tooltip = lang_Get_Snippet_New_Tooltip;
+						var tooltip = Joomla.JText._('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_INSTALL_IT_LOCALLY');
 					} else {
-						var tooltip = lang_Get_Snippet_Tooltip;
+						var tooltip = Joomla.JText._('COM_COMPONENTBUILDER_GET_THE_SNIPPET_FROM_GITHUB_AND_UPDATE_THE_LOCAL_VERSION');
 					}
-					html += '<button id=\"'+keyID+'-getbutton\" class=\"uk-button uk-button-small uk-button-primary uk-width-1-1 uk-margin-small-bottom getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"get\"  title=\"'+tooltip+'\"><i class=\"uk-icon-cloud-download\"></i> '+lang_Get_Snippet+'</button>';
+					html += '<button id=\"'+keyID+'-getbutton\" class=\"uk-button uk-button-small uk-button-primary uk-width-1-1 uk-margin-small-bottom getreaction\" data-status=\"'+status+'\" data-path=\"'+key+'\" data-type=\"get\"  title=\"'+tooltip+'\"><i class=\"uk-icon-cloud-download\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_GET_SNIPPET')+'</button>';
 				} else {
-					html += '<button class=\"uk-button uk-button-small uk-width-1-1 uk-margin-small-bottom\" type=\"button\" disabled title=\"'+lang_Get_Snippet_Dont_Tooltip+'\"><i class=\"uk-icon-check-square-o\"></i> '+lang_Dont_Get_Snippet+'</button>';
+					html += '<button class=\"uk-button uk-button-small uk-width-1-1 uk-margin-small-bottom\" type=\"button\" disabled title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_NO_NEED_TO_GET_IT_SINCE_IT_IS_ALREADY_IN_SYNC_WITH_YOUR_LOCAL_VERSION')+'\"><i class=\"uk-icon-check-square-o\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_LOCAL_SNIPPET')+'</button>';
 				}
 				html += '</div>';
 				// return data buttons
@@ -540,7 +540,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 				} else if (snippet.contributor_name) {
 					var contributor_name = snippet.contributor_name;
 				} else {
-					var contributor_name = lang_JCB_Community;
+					var contributor_name = Joomla.JText._('COM_COMPONENTBUILDER_JCB_COMMUNITY');
 				}
 				// set the contributor url
 				if (snippet.contributor_website) {
@@ -551,9 +551,9 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 					var contributor_url = 'https://github.com/vdm-io/Joomla-Component-Builder-Snippets';
 				}
 				var html = '<div class=\"uk-button-group uk-width-1-1\">';
-				html += '<button class=\"uk-button uk-button-primary uk-width-1-10 uk-button-mini getreaction\" data-type=\"contributor\" data-path=\"'+key+'\" title=\"'+lang_Contributor_Modal_Tooltip+'\"><i class=\"uk-icon-user\"></i></button>';
-				html += '<a  class=\"uk-button uk-button-primary uk-width-5-10 uk-button-mini\" href=\"'+contributor_url+'\" target=\"_blank\"  title=\"'+lang_Contributor_URL_Tooltip+'\"><i class=\"uk-icon-external-link\"></i> ' + contributor_name + '</a>';
-				html += '<a class=\"uk-button uk-button-primary uk-width-4-10 uk-button-mini\" href=\"https://github.com/vdm-io/Joomla-Component-Builder-Snippets/blame/master/'+key+'\" target=\"_blank\" title=\"'+lang_View_Blame_Tooltip+'\"><i class=\"uk-icon-external-link\"></i> '+lang_View_Blame+'</a>';
+				html += '<button class=\"uk-button uk-button-primary uk-width-1-10 uk-button-mini getreaction\" data-type=\"contributor\" data-path=\"'+key+'\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_THE_CONTRIBUTOR_DETAILS')+'\"><i class=\"uk-icon-user\"></i></button>';
+				html += '<a  class=\"uk-button uk-button-primary uk-width-5-10 uk-button-mini\" href=\"'+contributor_url+'\" target=\"_blank\"  title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_LINK_TO_THE_CONTRIBUTOR')+'\"><i class=\"uk-icon-external-link\"></i> ' + contributor_name + '</a>';
+				html += '<a class=\"uk-button uk-button-primary uk-width-4-10 uk-button-mini\" href=\"https://github.com/vdm-io/Joomla-Component-Builder-Snippets/blame/master/'+key+'\" target=\"_blank\" title=\"'+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_WHO_CONTRIBUTED_TO_THIS_SNIPPET')+'\"><i class=\"uk-icon-external-link\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_VIEW_BLAME')+'</a>';
 				html += '</div>';
 				// return contributor buttons
 				return html;
@@ -564,31 +564,31 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 				// check if there is new items
 				if (bulkItems.new.length === 0) {
 					jQuery('#bulk-button-new').prop('disabled', true);
-					jQuery('#bulk-button-new').attr('title', lang_Get_Snippets_New_Tooltip);
+					jQuery('#bulk-button-new').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_THERE_ARE_NO_NEW_SNIPPETS_AT_THIS_TIME'));
 					jQuery('#bulk-notice-new').show();
 				}
 				// check if there is diverged items
 				if (bulkItems.diverged.length === 0) {
 					jQuery('#bulk-button-diverged').prop('disabled', true);
-					jQuery('#bulk-button-diverged').attr('title', lang_Get_Snippets_Diverged_Tooltip);
+					jQuery('#bulk-button-diverged').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_THERE_ARE_NO_DIVERGED_SNIPPETS_AT_THIS_TIME'));
 					jQuery('#bulk-notice-diverged').show();
 				}
 				// check if there is ahead items
 				if (bulkItems.ahead.length === 0) {
 					jQuery('#bulk-button-ahead').prop('disabled', true);
-					jQuery('#bulk-button-ahead').attr('title', lang_Get_Snippets_Ahead_Tooltip);
+					jQuery('#bulk-button-ahead').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_THERE_ARE_NO_AHEAD_SNIPPETS_AT_THIS_TIME'));
 					jQuery('#bulk-notice-ahead').show();
 				}
 				// check if there is behind items
 				if (bulkItems.behind.length === 0) {
 					jQuery('#bulk-button-behind').prop('disabled', true);
-					jQuery('#bulk-button-behind').attr('title', lang_Get_Snippets_Behind_Tooltip);
+					jQuery('#bulk-button-behind').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_THERE_ARE_NO_OUT_OF_DATE_SNIPPETS_AT_THIS_TIME'));
 					jQuery('#bulk-notice-behind').show();
 				}
 				// check if all we should close the all button
 				if (bulkItems.behind.length === 0 && bulkItems.new.length === 0 && bulkItems.ahead.length === 0 && bulkItems.diverged.length === 0) {
 					jQuery('#bulk-button-all').prop('disabled', true);
-					jQuery('#bulk-button-all').attr('title', lang_Get_Snippets_All_Tooltip);
+					jQuery('#bulk-button-all').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_THERE_ARE_NO_SNIPPETS_TO_UPDATE_AT_THIS_TIME'));
 					jQuery('#bulk-notice-all').show();
 				}
 			}
@@ -618,7 +618,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 										updateSnippetDisplay(keyID, 'equal');
 									}
 								} else {
-									UIkit.notify(lang_Update_Error_Tooltip, {status:'danger'});
+									UIkit.notify(Joomla.JText._('COM_COMPONENTBUILDER_SNIPPET_COULD_NOT_BE_UPDATEDSAVED'), {status:'danger'});
 								}
 							});
 						}, 200);
@@ -661,7 +661,7 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 								updateSnippetDisplay(keyID, 'equal');
 							}
 						} else {
-							UIkit.notify(lang_Update_Error_Tooltip, {status:'danger'});
+							UIkit.notify(Joomla.JText._('COM_COMPONENTBUILDER_SNIPPET_COULD_NOT_BE_UPDATEDSAVED'), {status:'danger'});
 						}
 					});
 				});
@@ -691,9 +691,9 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 				// update button
 				if ('equal' === status) {
 					// update notice
-					jQuery('#'+keyID+'-getbutton').attr('title', lang_Get_Snippet_Dont_Tooltip);
+					jQuery('#'+keyID+'-getbutton').attr('title', Joomla.JText._('COM_COMPONENTBUILDER_NO_NEED_TO_GET_IT_SINCE_IT_IS_ALREADY_IN_SYNC_WITH_YOUR_LOCAL_VERSION'));
 					jQuery('#'+keyID+'-getbutton').prop('disabled', true);
-					jQuery('#'+keyID+'-getbutton').html('<i class=\"uk-icon-check-square-o\"></i> ' + lang_Dont_Get_Snippet);
+					jQuery('#'+keyID+'-getbutton').html('<i class=\"uk-icon-check-square-o\"></i> ' + Joomla.JText._('COM_COMPONENTBUILDER_LOCAL_SNIPPET'));
 					// counter delay just incase
 					setTimeout(function(){
 						jQuery('#'+keyID+'-getbutton').prop('disabled', true);
@@ -735,13 +735,13 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 				html += '<h3>' + snippet.library + ' - (' + snippet.type + ') ' + snippet.name + '</h3>';
 				if ('contributor' === type) {
 					html += '<dl class=\"uk-description-list-line\">';
-					html += '<dt><i class=\"uk-icon-institution\"></i> '+lang_Company_Name+'</dt>';
+					html += '<dt><i class=\"uk-icon-institution\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_COMPANY_NAME')+'</dt>';
 					html += '<dd>'+snippet.contributor_company+'</dd>';
-					html += '<dt><i class=\"uk-icon-user\"></i> '+lang_Author_Name+'</dt>';
+					html += '<dt><i class=\"uk-icon-user\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_AUTHOR_NAME')+'</dt>';
 					html += '<dd>'+snippet.contributor_name+'</dd>';
-					html += '<dt><i class=\"uk-icon-envelope-o\"></i> '+lang_Author_Email+'</dt>';
+					html += '<dt><i class=\"uk-icon-envelope-o\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_AUTHOR_EMAIL')+'</dt>';
 					html += '<dd>'+snippet.contributor_email+'</dd>';
-					html += '<dt><i class=\"uk-icon-laptop\"></i> '+lang_Author_Website+'</dt>';
+					html += '<dt><i class=\"uk-icon-laptop\"></i> '+Joomla.JText._('COM_COMPONENTBUILDER_AUTHOR_WEBSITE')+'</dt>';
 					html += '<dd>'+snippet.contributor_website+'</dd>';
 					html += '</dl>';
 				} else {

--- a/admin/views/get_snippets/view.html.php
+++ b/admin/views/get_snippets/view.html.php
@@ -189,7 +189,6 @@ class ComponentbuilderViewGet_snippets extends JViewLegacy
 		// set an error message if needed
 		$this->document->addScriptDeclaration("var returnError = '<div class=\"uk-alert uk-alert-warning\"><h1>".JText::_('COM_COMPONENTBUILDER_AN_ERROR_HAS_OCCURRED')."!</h1><p>".JText::_('COM_COMPONENTBUILDER_PLEASE_TRY_AGAIN_LATER').".</p></div>';");
 		// need to add some language strings
-		JText::script('COM_COMPONENTBUILDER_JCB_COMMUNITY_SNIPPETS');
 		JText::script('COM_COMPONENTBUILDER_SNIPPETS');
 		JText::script('COM_COMPONENTBUILDER_SNIPPET');
 		JText::script('COM_COMPONENTBUILDER_VIEW_SNIPPET_OF_COMMUNITY_VERSION');

--- a/admin/views/import_joomla_components/tmpl/default.php
+++ b/admin/views/import_joomla_components/tmpl/default.php
@@ -159,7 +159,7 @@ jQuery(document).ready(function($) {
 	<?php if ($this->hasPackage && ComponentbuilderHelper::checkArray($this->headerList) && ComponentbuilderHelper::checkArray($this->headers)) : ?>
 		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => $this->activeTab)); ?>
 
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', JText::_('Basic Method', true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic', JText::_('COM_COMPONENTBUILDER_BASIC_METHOD', true)); ?>
 		<fieldset class="uploadform">
 			<legend><?php echo JText::_('COM_COMPONENTBUILDER_IMPORT_LINK_FILE_TO_TABLE_COLUMNS'); ?></legend>
 			<div class="control-group">

--- a/componentbuilder.xml
+++ b/componentbuilder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="3.2" method="upgrade">
 	<name>COM_COMPONENTBUILDER</name>
-	<creationDate>12th December, 2017</creationDate>
+	<creationDate>14th December, 2017</creationDate>
 	<author>Llewellyn van der Merwe</author>
 	<authorEmail>joomla@vdm.io</authorEmail>
 	<authorUrl>http://vdm.bz/component-builder</authorUrl>


### PR DESCRIPTION
Pull Request for Issue gh-198 .

### Summary of Changes
Updated the compiler to also target JText::script() & Joomla.JText._() in language constant replacement. Added field counter. 

### Testing Instructions
add some JText::script() & Joomla.JText._() to your component site or custom admin view (custom script) areas and it should be converted.

### Expected result
Converting JText::script() & Joomla.JText._()

### Actual result
There was no implementation for this before.

### Documentation Changes Required
We may need to add some notes around the custom script areas to inform users of this feature.