### PR TITLE
Update e_Interpretation.php

### DIFF
--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -10013,7 +10013,7 @@ class Interpretation extends Fields
 					elseif ($default === 'DATETIME'
 						|| $default === 'CURRENT_TIMESTAMP')
 					{
-						$default = $default . ' ' . $data['null_switch'];
+						$default = $data['null_switch'] . ' ' . $default;
 					}
 					elseif ($default == 0 || $default)
 					{

--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -10013,7 +10013,7 @@ class Interpretation extends Fields
 					elseif ($default === 'DATETIME'
 						|| $default === 'CURRENT_TIMESTAMP')
 					{
-						$default = $data['null_switch'] . ' ' . $default;
+						$default = $data['null_switch'] . ' DEFAULT ' . $default;
 					}
 					elseif ($default == 0 || $default)
 					{


### PR DESCRIPTION
When field default is DATETIME or CURRENT_TIMESTAMP, the SQL is constructed out of order.  The default gets inserted before the NULL/NOT NULL string.  One line fix - YAY!

Pull Request for Issue gh-585 .

### Summary of Changes
Fixed compilation order

### Testing Instructions
Create datetime field with DATETIME or CURRENT_TIMESTAMP  as default

### Expected result
`received_timestamp` DATETIME NOT NULL CURRENT_TIMESTAMP

### Actual result
`received_timestamp` DATETIME NOT NULL CURRENT_TIMESTAMP

### Documentation Changes Required
none
