### PR TITLE
Urgent fix for Joomla 3.9.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ TODO
 + *Author*: [Llewellyn van der Merwe](mailto:llewellyn@joomlacomponentbuilder.com)
 + *Name*: [Component Builder](https://github.com/vdm-io/Joomla-Component-Builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 21st February, 2021
++ *Last Build*: 4th March, 2021
 + *Version*: 2.12.7
 + *Copyright*: Copyright (C) 2015 Vast Development Method. All rights reserved.
 + *License*: GNU General Public License version 2 or later; see LICENSE.txt
-+ *Line count*: **292151**
++ *Line count*: **292184**
 + *Field count*: **1629**
 + *File count*: **1935**
 + *Folder count*: **322**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Component Builder for [Joomla](https://extensions.joomla.org/extension/compo
 
 Whether you're a seasoned [Joomla](https://extensions.joomla.org/extension/component-builder/) developer, or have just started, Component Builder will save you lots of time and money. A real must have!
 
-You can install it quite easily and with no limitations. On [github](https://github.com/vdm-io/Joomla-Component-Builder/releases) is the latest release (2.12.7) with **ALL** its features and **ALL** concepts totally open-source and free! 
+You can install it quite easily and with no limitations. On [github](https://github.com/vdm-io/Joomla-Component-Builder/releases) is the latest release (2.12.8) with **ALL** its features and **ALL** concepts totally open-source and free! 
 
 > Watch Quick Build of a Hello World component in [JCB on Youtube](https://www.youtube.com/watch?v=IQfsLYIeblk&list=PLQRGFI8XZ_wtGvPQZWBfDzzlERLQgpMRE&index=45)
 
@@ -143,8 +143,8 @@ TODO
 + *Author*: [Llewellyn van der Merwe](mailto:llewellyn@joomlacomponentbuilder.com)
 + *Name*: [Component Builder](https://github.com/vdm-io/Joomla-Component-Builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 4th March, 2021
-+ *Version*: 2.12.7
++ *Last Build*: 5th March, 2021
++ *Version*: 2.12.8
 + *Copyright*: Copyright (C) 2015 Vast Development Method. All rights reserved.
 + *License*: GNU General Public License version 2 or later; see LICENSE.txt
 + *Line count*: **292184**

--- a/admin/README.txt
+++ b/admin/README.txt
@@ -143,11 +143,11 @@ TODO
 + *Author*: [Llewellyn van der Merwe](mailto:llewellyn@joomlacomponentbuilder.com)
 + *Name*: [Component Builder](https://github.com/vdm-io/Joomla-Component-Builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 21st February, 2021
++ *Last Build*: 4th March, 2021
 + *Version*: 2.12.7
 + *Copyright*: Copyright (C) 2015 Vast Development Method. All rights reserved.
 + *License*: GNU General Public License version 2 or later; see LICENSE.txt
-+ *Line count*: **292151**
++ *Line count*: **292184**
 + *Field count*: **1629**
 + *File count*: **1935**
 + *Folder count*: **322**

--- a/admin/README.txt
+++ b/admin/README.txt
@@ -12,7 +12,7 @@ The Component Builder for [Joomla](https://extensions.joomla.org/extension/compo
 
 Whether you're a seasoned [Joomla](https://extensions.joomla.org/extension/component-builder/) developer, or have just started, Component Builder will save you lots of time and money. A real must have!
 
-You can install it quite easily and with no limitations. On [github](https://github.com/vdm-io/Joomla-Component-Builder/releases) is the latest release (2.12.7) with **ALL** its features and **ALL** concepts totally open-source and free! 
+You can install it quite easily and with no limitations. On [github](https://github.com/vdm-io/Joomla-Component-Builder/releases) is the latest release (2.12.8) with **ALL** its features and **ALL** concepts totally open-source and free! 
 
 > Watch Quick Build of a Hello World component in [JCB on Youtube](https://www.youtube.com/watch?v=IQfsLYIeblk&list=PLQRGFI8XZ_wtGvPQZWBfDzzlERLQgpMRE&index=45)
 
@@ -143,8 +143,8 @@ TODO
 + *Author*: [Llewellyn van der Merwe](mailto:llewellyn@joomlacomponentbuilder.com)
 + *Name*: [Component Builder](https://github.com/vdm-io/Joomla-Component-Builder)
 + *First Build*: 30th April, 2015
-+ *Last Build*: 4th March, 2021
-+ *Version*: 2.12.7
++ *Last Build*: 5th March, 2021
++ *Version*: 2.12.8
 + *Copyright*: Copyright (C) 2015 Vast Development Method. All rights reserved.
 + *License*: GNU General Public License version 2 or later; see LICENSE.txt
 + *Line count*: **292184**

--- a/admin/controllers/compiler.php
+++ b/admin/controllers/compiler.php
@@ -255,8 +255,10 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 					$message[] = '<p><small><b>Remember!</b> This zip file is in your tmp folder and therefore publicly accessible until you click [Clear tmp]!</small> </p>';
 				}
 				$message[] = '<p><small>Compilation took <b>'.$model->compiler->secondsCompiled.'</b> seconds to complete.</small> </p>';
+				// pass the message via the user state... wow this is painful
+				$app->setUserState('com_componentbuilder.success_message', implode(PHP_EOL, $message));
 				// set redirect
-				$this->setRedirect($redirect_url, implode(PHP_EOL, $message), 'message');
+				$this->setRedirect($redirect_url, '<h2>Successful Build!</h2>', 'message');
 				$app->setUserState('com_componentbuilder.component_folder_name', $model->compiler->filepath['component-folder']);
 				// check if we have modules
 				if ($add_module_install)
@@ -278,6 +280,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 				$app->setUserState('com_componentbuilder.component_folder_name', '');
 				$app->setUserState('com_componentbuilder.modules_folder_name', '');
 				$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+				$app->setUserState('com_componentbuilder.success_message', '');
 				// set redirect
 				$this->setRedirect($redirect_url, $message);
 			}
@@ -318,6 +321,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 			$app->setUserState('com_componentbuilder.component_folder_name', '');
 			$app->setUserState('com_componentbuilder.modules_folder_name', '');
 			$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+			$app->setUserState('com_componentbuilder.success_message', '');
 
 			// loop and install all extensions found
 			foreach ($fileNames as $fileName)
@@ -372,6 +376,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 			$app->setUserState('com_componentbuilder.component_folder_name', '');
 			$app->setUserState('com_componentbuilder.modules_folder_name', '');
 			$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+			$app->setUserState('com_componentbuilder.success_message', '');
 
 			if ($this->installExtension($fileName))
 			{
@@ -409,6 +414,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 			$app->setUserState('com_componentbuilder.component_folder_name', '');
 			$app->setUserState('com_componentbuilder.modules_folder_name', '');
 			$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+			$app->setUserState('com_componentbuilder.success_message', '');
 
 			if (ComponentbuilderHelper::checkArray($fileNames))
 			{
@@ -451,6 +457,7 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 			$app->setUserState('com_componentbuilder.component_folder_name', '');
 			$app->setUserState('com_componentbuilder.modules_folder_name', '');
 			$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+			$app->setUserState('com_componentbuilder.success_message', '');
 
 			if (ComponentbuilderHelper::checkArray($fileNames))
 			{
@@ -564,6 +571,14 @@ class ComponentbuilderControllerCompiler extends JControllerAdmin
 			{
 				$message = JText::_('COM_COMPONENTBUILDER_BTHE_TMP_FOLDER_HAS_BEEN_CLEAR_SUCCESSFULLYB');
 				$this->setRedirect($redirect_url, $message, 'message');
+				// get application
+				$app = JFactory::getApplication();
+				// wipe out the user c-m-p since we are done with them all
+				$app->setUserState('com_componentbuilder.component_folder_name', '');
+				$app->setUserState('com_componentbuilder.modules_folder_name', '');
+				$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+				$app->setUserState('com_componentbuilder.success_message', '');
+
 				return true;
 			}
 		}

--- a/admin/controllers/joomla_components.php
+++ b/admin/controllers/joomla_components.php
@@ -172,6 +172,14 @@ class ComponentbuilderControllerJoomla_components extends JControllerAdmin
 			{
 				$message = JText::_('COM_COMPONENTBUILDER_BTHE_TMP_FOLDER_HAS_BEEN_CLEAR_SUCCESSFULLYB');
 				$this->setRedirect($redirect_url, $message, 'message');
+				// get application
+				$app = JFactory::getApplication();
+				// wipe out the user c-m-p since we are done with them all
+				$app->setUserState('com_componentbuilder.component_folder_name', '');
+				$app->setUserState('com_componentbuilder.modules_folder_name', '');
+				$app->setUserState('com_componentbuilder.plugins_folder_name', '');
+				$app->setUserState('com_componentbuilder.success_message', '');
+
 				return true;
 			}
 		}

--- a/admin/helpers/compiler/c_Fields.php
+++ b/admin/helpers/compiler/c_Fields.php
@@ -1315,21 +1315,24 @@ class Fields extends Structure
 			$tab_name   = "publishing";
 
 			$attributes = array(
-				'name'        => $field_name,
-				'type'        => 'hidden',
-				'default'      => $component . ' ' . $nameSingleCode
+				'name'    => $field_name,
+				'type'    => 'hidden',
+				'default' => $component . ' ' . $nameSingleCode
 			);
 			ComponentbuilderHelper::xmlComment(
 				$fieldSetXML,
-				$this->setLine(__LINE__) . " Was added due to Permissions JS needing a Title field"
+				$this->setLine(__LINE__)
+				. " Was added due to Permissions JS needing a Title field"
 			);
 			ComponentbuilderHelper::xmlComment(
 				$fieldSetXML,
-				$this->setLine(__LINE__) . " Let us know at gh-629 should this change"
+				$this->setLine(__LINE__)
+				. " Let us know at gh-629 should this change"
 			);
 			ComponentbuilderHelper::xmlComment(
 				$fieldSetXML,
-				$this->setLine(__LINE__) . " https://github.com/vdm-io/Joomla-Component-Builder/issues/629#issuecomment-750117235"
+				$this->setLine(__LINE__)
+				. " https://github.com/vdm-io/Joomla-Component-Builder/issues/629#issuecomment-750117235"
 			);
 			$fieldXML = $fieldSetXML->addChild('field');
 			ComponentbuilderHelper::xmlAddAttributes($fieldXML, $attributes);
@@ -1486,6 +1489,7 @@ class Fields extends Structure
 			{
 				// set the permission for later
 				$this->hasPermissions[$nameSingleCode] = true;
+
 				// break out here
 				return true;
 			}
@@ -1508,6 +1512,7 @@ class Fields extends Structure
 					{
 						// set the permission for later
 						$this->hasPermissions[$nameSingleCode] = true;
+
 						// break out here
 						return true;
 					}
@@ -1530,12 +1535,14 @@ class Fields extends Structure
 					{
 						// set the permission for later
 						$this->hasPermissions[$nameSingleCode] = true;
+
 						// break out here
 						return true;
 					}
 				}
 			}
 		}
+
 		return $this->hasPermissions[$nameSingleCode];
 	}
 
@@ -4981,7 +4988,8 @@ class Fields extends Structure
 			// load the category builder - TODO must move all to single view
 			$this->categoryBuilder[$nameListCode] = array('code'      => $name,
 			                                              'name'      => $listLangName,
-			                                              'extension' => $_extension);
+			                                              'extension' => $_extension,
+			                                              'filter'    => $field['filter']);
 			// also set code name for title alias fix
 			$this->catCodeBuilder[$nameSingleCode] = array('code'  => $name,
 			                                               'views' => $otherViews,
@@ -5800,7 +5808,9 @@ class Fields extends Structure
 				&& ComponentbuilderHelper::checkArray(
 					$this->categoryBuilder[$nameListCode]
 				)
-				&& isset($this->categoryBuilder[$nameListCode]['extension']))
+				&& isset($this->categoryBuilder[$nameListCode]['extension'])
+				&& isset($this->categoryBuilder[$nameListCode]['filter'])
+				&& $this->categoryBuilder[$nameListCode]['filter'] >= 1)
 			{
 				$field_filter_sets[] = $this->_t(2) . '<field';
 				$field_filter_sets[] = $this->_t(3) . 'type="category"';

--- a/admin/helpers/compiler/e_Interpretation.php
+++ b/admin/helpers/compiler/e_Interpretation.php
@@ -15723,10 +15723,13 @@ class Interpretation extends Fields
 		{
 			$categoryCodeName = $this->categoryBuilder[$nameListCode]['code'];
 			$addCategory      = true;
+			$addCategoryFilter
+			                  = $this->categoryBuilder[$nameListCode]['filter'];
 		}
 		else
 		{
-			$addCategory = false;
+			$addCategory       = false;
+			$addCategoryFilter = 0;
 		}
 		// setup the query
 		$query = "//" . $this->setLine(__LINE__) . " Get the user object.";
@@ -15842,7 +15845,7 @@ class Interpretation extends Fields
 		// set other filters
 		$query .= $this->setFilterQuery($nameListCode);
 		// add the category
-		if ($addCategory)
+		if ($addCategory && $addCategoryFilter >= 1)
 		{
 			$query .= PHP_EOL . PHP_EOL . $this->_t(2) . "//" . $this->setLine(
 					__LINE__
@@ -18653,7 +18656,9 @@ class Interpretation extends Fields
 			&& ComponentbuilderHelper::checkArray(
 				$this->categoryBuilder[$nameListCode]
 			)
-			&& isset($this->categoryBuilder[$nameListCode]['extension']))
+			&& isset($this->categoryBuilder[$nameListCode]['extension'])
+			&& isset($this->categoryBuilder[$nameListCode]['filter'])
+			&& $this->categoryBuilder[$nameListCode]['filter'] >= 1)
 		{
 			// set filter
 			$filter[] = PHP_EOL . $this->_t(2) . "//"
@@ -22442,7 +22447,9 @@ class Interpretation extends Fields
 				&& ComponentbuilderHelper::checkArray(
 					$this->categoryBuilder[$nameListCode]
 				)
-				&& isset($this->categoryBuilder[$nameListCode]['extension']))
+				&& isset($this->categoryBuilder[$nameListCode]['extension'])
+				&& isset($this->categoryBuilder[$nameListCode]['filter'])
+				&& $this->categoryBuilder[$nameListCode]['filter'] >= 1)
 			{
 				// is found so add it
 				$add_category = true;
@@ -22466,18 +22473,28 @@ class Interpretation extends Fields
 					if (isset($filter['multi'])
 						&& $filter['multi'] == 2)
 					{
+						// if this is a category we should make sure it must be added
+						if (!$add_category && $filter['type'] === 'category')
+						{
+							continue;
+						}
+						elseif ($add_category && $filter['type'] === 'category')
+						{
+							// already added here so no need to add again
+							$add_category = false;
+						}
+						// check if this was an access field
+						elseif ($filter['type'] === 'accesslevel')
+						{
+							// already added here so no need to add again
+							$add_access_levels = false;
+						}
 						// add the header
 						$headers[]
 							= 'JHtml::_(\'formbehavior.chosen\', \'.multiple'
 							. $filter['class']
 							. '\', null, array(\'placeholder_text_multiple\' => \'- \' . JText::_(\''
 							. $filter['lang_select'] . '\') . \' -\'));';
-						// check if this was an access field
-						if ($filter['type'] === 'accesslevel')
-						{
-							// already added here so no need to add again
-							$add_access_levels = false;
-						}
 					}
 					elseif ($add_category && $filter['type'] === 'category')
 					{

--- a/admin/models/compiler.php
+++ b/admin/models/compiler.php
@@ -154,7 +154,7 @@ class ComponentbuilderModelCompiler extends JModelList
 		$db->setQuery($query);
 		// return the result
 		return $db->loadObjectList();
-	}
+	}	
 
 	public function getCompilerAnimations(&$errorMessage) 
 	{

--- a/admin/views/compiler/tmpl/default.php
+++ b/admin/views/compiler/tmpl/default.php
@@ -50,7 +50,10 @@ Joomla.submitbutton = function(task, key)
 			}
 			// set the task value
 			form.task.value = task;
-			form.submit();
+			// seems we need a little delay here
+			setTimeout(function() {
+				form.submit();
+			}, 100);
 			// some ui movements
 			if (task == 'compiler.compiler'){
 				// get the component name
@@ -124,6 +127,12 @@ jQuery('<div id="compiling"></div>')
 <?php else : ?>
 <div id="j-main-container">
 <?php endif; ?>
+	<?php if (ComponentbuilderHelper::checkString($this->SuccessMessage)): ?>
+	<div class="alert alert-success">
+	<button type="button" class="close" data-dismiss="alert">×</button>
+		<?= $this->SuccessMessage; ?>
+	</div>
+	<?php endif; ?>
 	<div id="form">
 		<div class="span4">
 			<h3><?= JText::_('COM_COMPONENTBUILDER_READY_TO_COMPILE_A_COMPONENT') ?></h3>

--- a/admin/views/compiler/view.html.php
+++ b/admin/views/compiler/view.html.php
@@ -37,6 +37,7 @@ class ComponentbuilderViewCompiler extends JViewLegacy
 			JHtmlSidebar::setAction('index.php?option=com_componentbuilder&view=compiler');
 			$this->sidebar = JHtmlSidebar::render();
 		}
+		$this->SuccessMessage = $this->app->getUserState('com_componentbuilder.success_message', false);
 		$this->Components = $this->get('Components');
 		$this->form = $this->setForm();
 		// set the compiler artwork from global settings

--- a/componentbuilder.xml
+++ b/componentbuilder.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="3.2" method="upgrade">
 	<name>COM_COMPONENTBUILDER</name>
-	<creationDate>4th March, 2021</creationDate>
+	<creationDate>5th March, 2021</creationDate>
 	<author>Llewellyn van der Merwe</author>
 	<authorEmail>llewellyn@joomlacomponentbuilder.com</authorEmail>
 	<authorUrl>http://www.joomlacomponentbuilder.com</authorUrl>
 	<copyright>Copyright (C) 2015 Vast Development Method. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>2.12.7</version>
+	<version>2.12.8</version>
 	<description><![CDATA[
-		<h1>Component Builder (v.2.12.7)</h1>
+		<h1>Component Builder (v.2.12.8)</h1>
 		<div style="clear: both;"></div>
 		<p>The Component Builder for [Joomla](https://extensions.joomla.org/extension/component-builder/) is highly advanced tool that is truly able to build extremely complex components in a fraction of the time.
 

--- a/componentbuilder.xml
+++ b/componentbuilder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="component" version="3.2" method="upgrade">
 	<name>COM_COMPONENTBUILDER</name>
-	<creationDate>21st February, 2021</creationDate>
+	<creationDate>4th March, 2021</creationDate>
 	<author>Llewellyn van der Merwe</author>
 	<authorEmail>llewellyn@joomlacomponentbuilder.com</authorEmail>
 	<authorUrl>http://www.joomlacomponentbuilder.com</authorUrl>

--- a/componentbuilder_update_server.xml
+++ b/componentbuilder_update_server.xml
@@ -1024,10 +1024,10 @@
 		<description>Builds Complex Joomla Components</description>
 		<element>com_componentbuilder</element>
 		<type>component</type>
-		<version>2.12.7</version>
+		<version>2.12.8</version>
 		<infourl title="Component Builder!">http://www.joomlacomponentbuilder.com</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vdm-io/Joomla-Component-Builder/releases/download/v2.12.7/JCB_v2.12.7.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vdm-io/Joomla-Component-Builder/releases/download/v2.12.8/JCB_v2.12.8.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/script.php
+++ b/script.php
@@ -9250,7 +9250,7 @@ class com_componentbuilderInstallerScript
 			echo '<a target="_blank" href="http://www.joomlacomponentbuilder.com" title="Component Builder">
 				<img src="components/com_componentbuilder/assets/images/vdm-component.jpg"/>
 				</a>
-				<h3>Upgrade to Version 2.12.7 Was Successful! Let us know if anything is not working as expected.</h3>';
+				<h3>Upgrade to Version 2.12.8 Was Successful! Let us know if anything is not working as expected.</h3>';
 
 			// Set db if not set already.
 			if (!isset($db))


### PR DESCRIPTION
Pull Request for Issue gh-678.

### Summary of Changes
 Fixed gh-678 moved the compilation success message out of the redirection message to a user state message, that get loaded to the page on successful compilation. This preserves the button scripts needed to install the compiled packages.

### Testing Instructions
Upgrade to Joomla 3.9.25, and install this patch. Then the compiler page should work as expected.

### Expected result
That JCB would work in Joomla 3.9.25 as always.

### Actual result
The Joomla 3.9.25 update broke the compiler page installation buttons.