### PR TITLE
Solve the problem of repeating the siteview name twice by the router's build method

### DIFF
--- a/admin/compiler/joomla_3/router.php
+++ b/admin/compiler/joomla_3/router.php
@@ -56,7 +56,7 @@ class ###Component###Router extends JComponentRouterBase
 		{
 			$view = $query['view'];
 
-			if (empty($query['Itemid']))
+			if (empty($query['Itemid']) && !(isset($view) && isset($query['id']) && ###ROUTER_BUILD_VIEWS###))
 			{
 				$segments[] = $query['view'];
 			}


### PR DESCRIPTION
 when we build link with ID and without Itemid, router's build method repeats siteview name twice in 'SEF' situation.
like:
mysite.com/index.php/component/componentname/siteviewname/siteviewname/id
